### PR TITLE
Make project installable

### DIFF
--- a/qt/fstl.pro
+++ b/qt/fstl.pro
@@ -44,3 +44,6 @@ win32 {
 static {
     CONFIG += static
 }
+
+target.path = /usr/bin
+INSTALLS += target


### PR DESCRIPTION
This adds an install target to the resulting makefile which especially
helps maintainers of distribution packages.