### PR TITLE
Small Fix for Windows

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -98,7 +98,7 @@ void Window::on_open()
 {
     QString filename = QFileDialog::getOpenFileName(
                 this, "Load .stl file", QString(), "*.stl");
-    if (not filename.isNull())
+    if (!filename.isNull())
     {
         load_stl(filename);
     }


### PR DESCRIPTION
Removed `not` operator in if statement. This doesn't play nice on windows. 