### PR TITLE
CMake Support and Small Fixes for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 #### Fast .stl viewer #####
-# Copyright 2016
-# Original Project Author: Matt Keeter 2014
-# Author: Paul Tsouchlos
+# Original Project Author: Matt Keeter Copyright 2014 -2017
+# Author: Paul Tsouchlos Copyright 2017
 
 cmake_minimum_required(VERSION 3.3)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This should produce two new files in the root directory:
 
 # License
 
-Copyright (c) 2014 Matthew Keeter
+Copyright (c) 2014-2017 Matthew Keeter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd ../app
 
 This should produce two new files in the root directory:
 - `fstl.app` is a standalone application that can be copied to `/Applications`
-- `fstl_mac.zip` is a zipped up bundle that can be given to a friend
+- `fstl.dmg` is a disk image that can be given to a friend
 
 --------------------------------------------------------------------------------
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -111,7 +111,7 @@ void Window::on_about()
         "<p>A fast viewer for <code>.stl</code> files.<br>"
         "<a href=\"https://github.com/mkeeter/fstl\""
         "   style=\"color: #93a1a1;\">https://github.com/mkeeter/fstl</a></p>"
-        "<p>© 2014 Matthew Keeter<br>"
+        "<p>© 2014-2017 Matthew Keeter<br>"
         "<a href=\"mailto:matt.j.keeter@gmail.com\""
         "   style=\"color: #93a1a1;\">matt.j.keeter@gmail.com</a></p>");
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -98,7 +98,7 @@ void Window::on_open()
 {
     QString filename = QFileDialog::getOpenFileName(
                 this, "Load .stl file", QString(), "*.stl");
-    if (not filename.isNull())
+    if (!filename.isNull())
     {
         load_stl(filename);
     }


### PR DESCRIPTION
What I did:
* Added cmake support (including installer generation)
* Small fix where `QSettings` wasn't properly saving values (see [here](http://doc.qt.io/qt-5/qsettings.html#details)).
* Made `parallel_sort()` function check for how many concurrent threads the hardware supports and use that value, if it is valid, for the number of threads to use during sorting.  

Notes:
* Mac OS installer part of the cmakelists is incomplete as I don't have a mac to test on. What I added should work but may be incomplete. 