### PR TITLE
Fix Mesh move constructor by explicit calling std::move for the vectors

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -9,7 +9,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 Mesh::Mesh(std::vector<GLfloat>&& v, std::vector<GLuint>&& i)
-    : vertices(v), indices(i)
+    : vertices(std::move(v)), indices(std::move(i))
 {
     // Nothing to do here
 }


### PR DESCRIPTION
The move constructor of the Mesh class was copying both vectors because std::move wasn't being called inside the constructor.