### PR TITLE
Migrate to QOpenGL Classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ find_package(Threads REQUIRED)
 #add resources to RCC
 qt5_add_resources(Project_Resources_RCC ${Project_Resources})
 
+#tell CMake AUTOGEN to skip autogen on the generated qrc files
+set_property(SOURCE ${Project_Resources_RCC} PROPERTY SKIP_AUTOGEN ON)
+
 #include opengl files. 
 include_directories(${QT_QTOPENGL_INCLUDE_DIR} ${OPENGL_INCLUDE_DIR} )
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -18,6 +18,11 @@ App::App(int& argc, char *argv[]) :
     window->show();
 }
 
+App::~App()
+{
+	delete window;
+}
+
 bool App::event(QEvent* e)
 {
     if (e->type() == QEvent::FileOpen)

--- a/src/app.h
+++ b/src/app.h
@@ -10,8 +10,9 @@ class App : public QApplication
     Q_OBJECT
 public:
     explicit App(int& argc, char *argv[]);
+	~App();
 protected:
-    bool event(QEvent* e);
+    bool event(QEvent* e) override;
 private:
     Window* const window;
 

--- a/src/backdrop.cpp
+++ b/src/backdrop.cpp
@@ -2,10 +2,10 @@
 
 Backdrop::Backdrop()
 {
-    initializeGLFunctions();
+    initializeOpenGLFunctions();
 
-    shader.addShaderFromSourceFile(QGLShader::Vertex, ":/gl/quad.vert");
-    shader.addShaderFromSourceFile(QGLShader::Fragment, ":/gl/quad.frag");
+    shader.addShaderFromSourceFile(QOpenGLShader::Vertex, ":/gl/quad.vert");
+    shader.addShaderFromSourceFile(QOpenGLShader::Fragment, ":/gl/quad.frag");
     shader.link();
 
     float vbuf[] = {

--- a/src/backdrop.h
+++ b/src/backdrop.h
@@ -1,18 +1,18 @@
 #ifndef BACKDROP_H
 #define BACKDROP_H
 
-#include <QtOpenGL/QGLFunctions>
-#include <QtOpenGL/QGLShaderProgram>
-#include <QtOpenGL/QGLBuffer>
+#include <QOpenGLBuffer>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLFunctions>
 
-class Backdrop : protected QGLFunctions
+class Backdrop : protected QOpenGLFunctions
 {
 public:
     Backdrop();
     void draw();
 private:
-    QGLShaderProgram shader;
-    QGLBuffer vertices;
+    QOpenGLShaderProgram shader;
+    QOpenGLBuffer vertices;
 };
 
 #endif // BACKDROP_H

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -1,5 +1,4 @@
 #include <QMouseEvent>
-#include <QDebug>
 
 #include <cmath>
 

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -1,26 +1,20 @@
 #ifndef CANVAS_H
 #define CANVAS_H
 
-#include <QWidget>
-#include <QPropertyAnimation>
-#include <QtOpenGL/QGLWidget>
-#include <QtOpenGL/QGLFunctions>
-#include <QtOpenGL/QGLShaderProgram>
-#include <QMatrix4x4>
+#include <QtOpenGL>
+#include <QSurfaceFormat>
+#include <QOpenGLShaderProgram>
 
 class GLMesh;
 class Mesh;
 class Backdrop;
 
-class Canvas : public QGLWidget, protected QGLFunctions
+class Canvas : public QOpenGLWidget, protected QOpenGLFunctions
 {
     Q_OBJECT
 
 public:
-    Canvas(const QGLFormat& format, QWidget* parent=0);
-
-    void initializeGL();
-    void paintEvent(QPaintEvent* event);
+	explicit Canvas(const QSurfaceFormat& format, QWidget* parent=0);
     ~Canvas();
 
     void view_orthographic();
@@ -31,16 +25,18 @@ public slots:
     void clear_status();
     void load_mesh(Mesh* m, bool is_reload);
 
-
 protected:
-    void mousePressEvent(QMouseEvent* event);
-    void mouseReleaseEvent(QMouseEvent* event);
-    void mouseMoveEvent(QMouseEvent* event);
-    void wheelEvent(QWheelEvent* event);
-    void resizeGL(int width, int height);
-    void set_perspective(float p);
-    void view_anim(float v);
+	void paintGL() override;
+	void initializeGL() override;
+	void resizeGL(int width, int height) override;
 
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
+    
+	void set_perspective(float p);
+    void view_anim(float v);
 
 private:
     void draw_mesh();
@@ -48,8 +44,8 @@ private:
     QMatrix4x4 transform_matrix() const;
     QMatrix4x4 view_matrix() const;
 
-    QGLShaderProgram mesh_shader;
-    QGLShaderProgram quad_shader;
+    QOpenGLShaderProgram mesh_shader;
+	QOpenGLShaderProgram quad_shader;
 
     GLMesh* mesh;
     Backdrop* backdrop;

--- a/src/glmesh.cpp
+++ b/src/glmesh.cpp
@@ -2,15 +2,15 @@
 #include "mesh.h"
 
 GLMesh::GLMesh(const Mesh* const mesh)
-    : vertices(QGLBuffer::VertexBuffer), indices(QGLBuffer::IndexBuffer)
+    : vertices(QOpenGLBuffer::VertexBuffer), indices(QOpenGLBuffer::IndexBuffer)
 {
-    initializeGLFunctions();
+    initializeOpenGLFunctions();
 
     vertices.create();
     indices.create();
 
-    vertices.setUsagePattern(QGLBuffer::StaticDraw);
-    indices.setUsagePattern(QGLBuffer::StaticDraw);
+    vertices.setUsagePattern(QOpenGLBuffer::StaticDraw);
+    indices.setUsagePattern(QOpenGLBuffer::StaticDraw);
 
     vertices.bind();
     vertices.allocate(mesh->vertices.data(),

--- a/src/glmesh.h
+++ b/src/glmesh.h
@@ -1,19 +1,20 @@
 #ifndef GLMESH_H
 #define GLMESH_H
 
-#include <QtOpenGL/QGLBuffer>
-#include <QtOpenGL/QGLFunctions>
+#include <QOpenGLBuffer>
+#include <QOpenGLFunctions>
 
+// forward declaration
 class Mesh;
 
-class GLMesh : protected QGLFunctions
+class GLMesh : protected QOpenGLFunctions
 {
 public:
     GLMesh(const Mesh* const mesh);
     void draw(GLuint vp);
 private:
-    QGLBuffer vertices;
-    QGLBuffer indices;
+	QOpenGLBuffer vertices;
+	QOpenGLBuffer indices;
 };
 
 #endif // GLMESH_H

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -26,10 +26,14 @@ Window::Window(QWidget *parent) :
     setWindowTitle("fstl");
     setAcceptDrops(true);
 
-    QGLFormat format;
-    format.setVersion(2, 1);
-    format.setSampleBuffers(true);
+    QSurfaceFormat format;
+	format.setDepthBufferSize(24);
+	format.setStencilBufferSize(8);
+	format.setVersion(2, 1);
+	format.setProfile(QSurfaceFormat::CoreProfile);
 
+	QSurfaceFormat::setDefaultFormat(format);
+	
     canvas = new Canvas(format, this);
     setCentralWidget(canvas);
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1,6 +1,4 @@
 #include <QMenuBar>
-#include <QMessageBox>
-#include <QFileDialog>
 
 #include "window.h"
 #include "canvas.h"

--- a/src/window.h
+++ b/src/window.h
@@ -15,8 +15,8 @@ public:
     bool load_stl(const QString& filename, bool is_reload=false);
 
 protected:
-    void dragEnterEvent(QDragEnterEvent* event);
-    void dropEvent(QDropEvent* event);
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
 
 public slots:
     void on_open();


### PR DESCRIPTION
## Changed
* Migrated all `QGL*` classes to their `QOpenGL*` variants (resolves #29). 

## Added/Fixed
* `override` specification to re-implemented virtual methods. 
* `explicit` keywords to make classes non-converting. 