### PR TITLE
it fails to compile without the compiler gets -std=c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@
 
 cmake_minimum_required(VERSION 3.3)
 
+# Setting -std=c++11
+set(CMAKE_CXX_STANDARD 11)
+
 # Set the version number
 set (FSTL_VERSION_MAJOR "0")
 set (FSTL_VERSION_MINOR "9")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 3.3)
 
 # Setting -std=c++11
 set(CMAKE_CXX_STANDARD 11)
+# Setting standard to required, as requisted by DeveloperPaul123 on github
+set(CXX_STANDARD_REQUIRED ON)
 
 # Set the version number
 set (FSTL_VERSION_MAJOR "0")


### PR DESCRIPTION
On elementary os (ubuntu based) it fails to compile without explicit setting compiler to use c++11.
Testet with g++ (Ubuntu 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609