### PR TITLE
Wireframe Draw Mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ src/window.h)
 set(Project_Resources qt/qt.qrc gl/gl.qrc)
 set(Icon_Resource exe/fstl.rc)
 
+#set Policy CMP0072 FindOpenGL behavior
+set(OpenGL_GL_PREFERENCE GLVND)
+
 #find required packages. 
 find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets OpenGL)
 find_package(OpenGL REQUIRED)

--- a/gl/gl.qrc
+++ b/gl/gl.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="gl/">
         <file>mesh.frag</file>
         <file>mesh.vert</file>
+        <file>mesh_wireframe.frag</file>
         <file>quad.frag</file>
         <file>quad.vert</file>
         <file>sphere.stl</file>

--- a/gl/mesh_wireframe.frag
+++ b/gl/mesh_wireframe.frag
@@ -1,0 +1,9 @@
+#version 120
+
+uniform float zoom;
+
+varying vec3 ec_pos;
+
+void main() {
+    gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+}

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -19,6 +19,8 @@ public:
 
     void view_orthographic();
     void view_perspective();
+    void draw_shaded();
+    void draw_wireframe();
 
 public slots:
     void set_status(const QString& s);
@@ -36,6 +38,7 @@ protected:
     void wheelEvent(QWheelEvent* event) override;
     
 	void set_perspective(float p);
+    void set_drawMode(int mode);
     void view_anim(float v);
 
 private:
@@ -45,6 +48,7 @@ private:
     QMatrix4x4 view_matrix() const;
 
     QOpenGLShaderProgram mesh_shader;
+    QOpenGLShaderProgram mesh_wireframe_shader;
 	QOpenGLShaderProgram quad_shader;
 
     GLMesh* mesh;
@@ -57,6 +61,7 @@ private:
     float yaw;
 
     float perspective;
+    int drawMode;
     Q_PROPERTY(float perspective MEMBER perspective WRITE set_perspective);
     QPropertyAnimation anim;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -13,6 +13,8 @@ Window::Window(QWidget *parent) :
     quit_action(new QAction("Quit", this)),
     perspective_action(new QAction("Perspective", this)),
     orthogonal_action(new QAction("Orthographic", this)),
+    shaded_action(new QAction("Shaded", this)),
+    wireframe_action(new QAction("Wireframe", this)),
     reload_action(new QAction("Reload", this)),
     autoreload_action(new QAction("Autoreload", this)),
     recent_files(new QMenu("Open recent", this)),
@@ -89,6 +91,20 @@ Window::Window(QWidget *parent) :
     projections->setExclusive(true);
     QObject::connect(projections, &QActionGroup::triggered,
                      this, &Window::on_projection);
+
+    auto draw_menu = view_menu->addMenu("Draw Mode");
+    draw_menu->addAction(shaded_action);
+    draw_menu->addAction(wireframe_action);
+    auto drawModes = new QActionGroup(draw_menu);
+    for (auto p : {shaded_action, wireframe_action})
+    {
+        drawModes->addAction(p);
+        p->setCheckable(true);
+    }
+    shaded_action->setChecked(true);
+    drawModes->setExclusive(true);
+    QObject::connect(drawModes, &QActionGroup::triggered,
+                     this, &Window::on_drawMode);
 
     auto help_menu = menuBar()->addMenu("Help");
     help_menu->addAction(about_action);
@@ -189,6 +205,18 @@ void Window::on_projection(QAction* proj)
     else
     {
         canvas->view_orthographic();
+    }
+}
+
+void Window::on_drawMode(QAction* mode)
+{
+    if (mode == shaded_action)
+    {
+        canvas->draw_shaded();
+    }
+    else
+    {
+        canvas->draw_wireframe();
     }
 }
 

--- a/src/window.h
+++ b/src/window.h
@@ -33,6 +33,7 @@ public slots:
 
 private slots:
     void on_projection(QAction* proj);
+    void on_drawMode(QAction* mode);
     void on_watched_change(const QString& filename);
     void on_reload();
     void on_autoreload_triggered(bool r);
@@ -47,6 +48,8 @@ private:
     QAction* const quit_action;
     QAction* const perspective_action;
     QAction* const orthogonal_action;
+    QAction* const shaded_action;
+    QAction* const wireframe_action;
     QAction* const reload_action;
     QAction* const autoreload_action;
 


### PR DESCRIPTION
I have added a "draw style" submenu under "view." This has two options, "shaded" and "wireframe."
Shaded is classic mode. Wireframe uses GL_LINE.

I also made a custom plain-white fragment shader for wireframe to avoid it looking nasty.

Sadly, I do not have access to Windows or Mac build environments, so I have only tested this on 64bit Linux.
Respectfully yours,
Martin