### PR TITLE
Fix initial settings

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -7,10 +7,6 @@
 App::App(int& argc, char *argv[]) :
     QApplication(argc, argv), window(new Window())
 {
-    QCoreApplication::setOrganizationName("mkeeter");
-    QCoreApplication::setOrganizationDomain("https://github.com/mkeeter/fstl");
-    QCoreApplication::setApplicationName("fstl");
-
     if (argc > 1)
         window->load_stl(argv[1]);
     else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,9 @@
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setOrganizationName("mkeeter");
+    QCoreApplication::setOrganizationDomain("https://github.com/mkeeter/fstl");
+    QCoreApplication::setApplicationName("fstl");
     App a(argc, argv);
     return a.exec();
 }


### PR DESCRIPTION
 When opening fstl, the initial `rebuild_recent_files` (window.cpp, 75) fails because the QCoreApplication set functions (which are used to determine the location for persistent settings files) have not yet been set. The initial rebuild happens as part of `window(new Window())` in the initialization section of the app constructor, but the core application settings get set later in the app construction.
 This pull moves those core application setting assignments to main.cpp so that any settings loaded as any part of the app will always know where they should read from.