### PR TITLE
Show axes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(CMAKE_AUTOUIC ON)
 #set project sources
 set(Project_Sources src/app.cpp
 src/backdrop.cpp
+src/axis.cpp
 src/canvas.cpp
 src/glmesh.cpp
 src/loader.cpp
@@ -34,6 +35,7 @@ src/window.cpp)
 #set project headers. 
 set(Project_Headers src/app.h
 src/backdrop.h
+src/axis.h
 src/canvas.h
 src/glmesh.h
 src/loader.h

--- a/gl/colored_lines.frag
+++ b/gl/colored_lines.frag
@@ -1,0 +1,7 @@
+#version 120
+
+varying vec3 frag_color;
+
+void main() {
+    gl_FragColor = vec4(frag_color, 1.0);
+}

--- a/gl/colored_lines.vert
+++ b/gl/colored_lines.vert
@@ -1,0 +1,14 @@
+#version 120
+attribute vec3 vertex_position;
+attribute vec3 vertex_color;
+
+uniform mat4 transform_matrix;
+uniform mat4 view_matrix;
+
+varying vec3 frag_color;
+
+void main() {
+    gl_Position = view_matrix*transform_matrix*
+        vec4(vertex_position, 1.0);
+    frag_color = vertex_color;
+}

--- a/gl/gl.qrc
+++ b/gl/gl.qrc
@@ -5,6 +5,8 @@
         <file>mesh_wireframe.frag</file>
         <file>quad.frag</file>
         <file>quad.vert</file>
+        <file>colored_lines.frag</file>
+        <file>colored_lines.vert</file>
         <file>sphere.stl</file>
     </qresource>
 </RCC>

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -16,7 +16,7 @@ App::App(int& argc, char *argv[]) :
 
 App::~App()
 {
-	delete window;
+    delete window;
 }
 
 bool App::event(QEvent* e)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -7,10 +7,6 @@
 App::App(int& argc, char *argv[]) :
     QApplication(argc, argv), window(new Window())
 {
-    QCoreApplication::setOrganizationName("mkeeter");
-    QCoreApplication::setOrganizationDomain("https://github.com/mkeeter/fstl");
-    QCoreApplication::setApplicationName("fstl");
-
     if (argc > 1)
         window->load_stl(argv[1]);
     else

--- a/src/axis.cpp
+++ b/src/axis.cpp
@@ -1,0 +1,55 @@
+#include "axis.h"
+
+Axis::Axis()
+{
+    initializeOpenGLFunctions();
+
+    shader.addShaderFromSourceFile(QOpenGLShader::Vertex, ":/gl/colored_lines.vert");
+    shader.addShaderFromSourceFile(QOpenGLShader::Fragment, ":/gl/colored_lines.frag");
+    shader.link();
+
+    float vbuf[] = {
+        1.0, 0.0, 0.0, 0.9, 0.0, 0.0, //X Axis
+        -1.0, 0.0, 0.0, 0.9, 0.0, 0.0,
+        0.0, 1.0, 0.0, 0.0, 0.9, 0.0, //Y Axis
+        0.0, -1.0, 0.0, 0.0, 0.9, 0.0,
+        0.0, 0.0, 1.0, 0.0, 0.0, 0.9, //Z Axis
+        0.0, 0.0, -1.0, 0.0, 0.0, 0.9};
+
+    vertices.create();
+    vertices.bind();
+    vertices.allocate(vbuf, sizeof(vbuf));
+    vertices.release();
+}
+void Axis::setScale(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax)
+{
+}
+void Axis::draw(QMatrix4x4 transMat, QMatrix4x4 viewMat)
+{
+    shader.bind();
+    vertices.bind();
+    // Load the transform and view matrices into the shader
+    glUniformMatrix4fv(
+                shader.uniformLocation("transform_matrix"),
+                1, GL_FALSE, transMat.data());
+    glUniformMatrix4fv(
+                shader.uniformLocation("view_matrix"),
+                1, GL_FALSE, viewMat.data());
+
+    const GLuint vp = shader.attributeLocation("vertex_position");
+    const GLuint vc = shader.attributeLocation("vertex_color");
+
+    glEnableVertexAttribArray(vp);
+    glEnableVertexAttribArray(vc);
+
+    glVertexAttribPointer(vp, 3, GL_FLOAT, false,
+                          6 * sizeof(GLfloat), 0);
+    glVertexAttribPointer(vc, 3, GL_FLOAT, false,
+                          6 * sizeof(GLfloat),
+                          (GLvoid*)(3 * sizeof(GLfloat)));
+
+    glDrawArrays(GL_LINES, 0, 18);
+
+    vertices.release();
+    shader.release();
+}

--- a/src/axis.cpp
+++ b/src/axis.cpp
@@ -1,6 +1,11 @@
 #include "axis.h"
-
 Axis::Axis()
+    : vbuf {1, 0, 0, 1, 0, 0, //X Axis
+        -1, 0, 0, 1, 0, 0,
+        0, 1, 0, 0, 1, 0, //Y Axis
+        0, -1, 0, 0, 1, 0,
+        0, 0, 1, 0, 0, 1, //Z Axis
+        0, 0, -1, 0, 0, 1}
 {
     initializeOpenGLFunctions();
 
@@ -8,14 +13,37 @@ Axis::Axis()
     shader.addShaderFromSourceFile(QOpenGLShader::Fragment, ":/gl/colored_lines.frag");
     shader.link();
 
-    float vbuf[] = {
-        1.0, 0.0, 0.0, 0.9, 0.0, 0.0, //X Axis
-        -1.0, 0.0, 0.0, 0.9, 0.0, 0.0,
-        0.0, 1.0, 0.0, 0.0, 0.9, 0.0, //Y Axis
-        0.0, -1.0, 0.0, 0.0, 0.9, 0.0,
-        0.0, 0.0, 1.0, 0.0, 0.0, 0.9, //Z Axis
-        0.0, 0.0, -1.0, 0.0, 0.0, 0.9};
+    float hud_vbuf[] = {0, 0, 0, 1, 0, 0, //X Axis
+        1, 0, 0, 1, 0, 0,
+        1.1, 0.1, 0, 1, 0, 0, //X Letter
+        1.5, -0.1, 0, 1, 0, 0,
+        1.1, -0.1, 0, 1, 0, 0,
+        1.5, 0.1, 0, 1, 0, 0,
 
+        0, 0, 0, 0, 1, 0, //Y Axis
+        0, 1, 0, 0, 1, 0,
+        0, 1.1, 0, 0, 1, 0, //Y Letter
+        0, 1.3, 0, 0, 1, 0,
+        0, 1.3, 0, 0, 1, 0,
+        0, 1.5, 0.1, 0, 1, 0,
+        0, 1.3, 0, 0, 1, 0,
+        0, 1.5, -0.1, 0, 1, 0,
+
+        0, 0, 0, 0, 0, 1, //Z Axis
+        0, 0, 1, 0, 0, 1,
+        0.1, 0, 1.1, 0, 0, 1, //Z Letter
+        -0.1, 0, 1.1, 0, 0, 1,
+        -0.1, 0, 1.1, 0, 0, 1,
+        0.1, 0, 1.5, 0, 0, 1,
+        0.1, 0, 1.5, 0, 0, 1,
+        -0.1, 0, 1.5, 0, 0, 1,
+    };
+    //The lines which form the 'axis-flower' in the corner
+    hud_vertices.create();
+    hud_vertices.bind();
+    hud_vertices.allocate(hud_vbuf, sizeof(hud_vbuf));
+    hud_vertices.release();
+    //The lines which form the model-space axes
     vertices.create();
     vertices.bind();
     vertices.allocate(vbuf, sizeof(vbuf));
@@ -23,8 +51,27 @@ Axis::Axis()
 }
 void Axis::setScale(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax)
 {
+    //Max function. not worth importing <algorithm> just for max
+    auto max = [](float a, float b)
+    {
+        return (a > b) ? a : b;
+    };
+    //This is how much the axes extend beyond the model
+    //We want it to be dependent on the model's size, but uniform on all axes.
+    const float axismargin = 0.25*max(max(xmax-xmin, ymax-ymin), zmax-zmin);
+    //Manually rewrite coordinates to control axis draw lengths
+    vbuf[0] = xmin-axismargin;
+    vbuf[6] = xmax+axismargin;
+    vbuf[13] = ymin-axismargin;
+    vbuf[19] = ymax+axismargin;
+    vbuf[26] = zmin-axismargin;
+    vbuf[32] = zmax+axismargin;
+    vertices.bind();
+    vertices.write(0, vbuf, sizeof(vbuf));
+    vertices.release();
 }
-void Axis::draw(QMatrix4x4 transMat, QMatrix4x4 viewMat)
+void Axis::draw(QMatrix4x4 transMat, QMatrix4x4 viewMat,
+    QMatrix4x4 orientMat, QMatrix4x4 aspectMat, float aspectRatio)
 {
     shader.bind();
     vertices.bind();
@@ -48,8 +95,40 @@ void Axis::draw(QMatrix4x4 transMat, QMatrix4x4 viewMat)
                           6 * sizeof(GLfloat),
                           (GLvoid*)(3 * sizeof(GLfloat)));
 
-    glDrawArrays(GL_LINES, 0, 18);
+    glDrawArrays(GL_LINES, 0, 3*6);
 
     vertices.release();
+    //Next, we draw the hud axis-flower
+    hud_vertices.bind();
+    glClear(GL_DEPTH_BUFFER_BIT);//Ensure hud draws over everything
+    const float hudSize = 0.2;
+    QMatrix4x4 hudMat;
+    //Move the hud to the bottom left corner with margin
+    if(aspectRatio > 1.0)
+    {
+        hudMat.translate(aspectRatio-2*hudSize, -1.0+2*hudSize, 0);
+    }
+    else
+    {
+        hudMat.translate(1.0-2*hudSize, -1.0/aspectRatio+2*hudSize, 0);
+    }
+    //Scale the hud to be small
+    hudMat.scale(hudSize, hudSize, 1);
+    glClear(GL_DEPTH_BUFFER_BIT);//Ensure hud draws over everything else
+    glUniformMatrix4fv(
+                shader.uniformLocation("view_matrix"),
+                1, GL_FALSE, (aspectMat*hudMat).data());
+    glUniformMatrix4fv(
+                shader.uniformLocation("transform_matrix"),
+                1, GL_FALSE, orientMat.data());
+
+    glVertexAttribPointer(vp, 3, GL_FLOAT, false,
+                          6 * sizeof(GLfloat), 0);
+    glVertexAttribPointer(vc, 3, GL_FLOAT, false,
+                          6 * sizeof(GLfloat),
+                          (GLvoid*)(3 * sizeof(GLfloat)));
+
+    glDrawArrays(GL_LINES, 0, 3*22);
     shader.release();
+    hud_vertices.release();
 }

--- a/src/axis.cpp
+++ b/src/axis.cpp
@@ -104,7 +104,7 @@ void Axis::draw(QMatrix4x4 transMat, QMatrix4x4 viewMat,
     const float hudSize = 0.2;
     QMatrix4x4 hudMat;
     //Move the hud to the bottom left corner with margin
-    if(aspectRatio > 1.0)
+    if (aspectRatio > 1.0)
     {
         hudMat.translate(aspectRatio-2*hudSize, -1.0+2*hudSize, 0);
     }

--- a/src/axis.cpp
+++ b/src/axis.cpp
@@ -114,7 +114,6 @@ void Axis::draw(QMatrix4x4 transMat, QMatrix4x4 viewMat,
     }
     //Scale the hud to be small
     hudMat.scale(hudSize, hudSize, 1);
-    glClear(GL_DEPTH_BUFFER_BIT);//Ensure hud draws over everything else
     glUniformMatrix4fv(
                 shader.uniformLocation("view_matrix"),
                 1, GL_FALSE, (aspectMat*hudMat).data());

--- a/src/axis.h
+++ b/src/axis.h
@@ -1,0 +1,19 @@
+#ifndef AXIS_H
+#define AXIS_H
+
+#include <QOpenGLBuffer>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLFunctions>
+
+class Axis : protected QOpenGLFunctions
+{
+public:
+    Axis();
+    void setScale(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax);
+    void draw(QMatrix4x4 transMat, QMatrix4x4 viewMat);
+private:
+    QOpenGLShaderProgram shader;
+    QOpenGLBuffer vertices;
+};
+
+#endif // AXIS_H

--- a/src/axis.h
+++ b/src/axis.h
@@ -9,11 +9,15 @@ class Axis : protected QOpenGLFunctions
 {
 public:
     Axis();
-    void setScale(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax);
-    void draw(QMatrix4x4 transMat, QMatrix4x4 viewMat);
+    void setScale(float xmin, float xmax, float ymin, float ymax,
+        float zmin, float zmax);
+    void draw(QMatrix4x4 transMat, QMatrix4x4 viewMat,
+        QMatrix4x4 orientMat, QMatrix4x4 aspectMat, float aspectRatio);
 private:
+    void drawHud(QMatrix4x4 transMat, QMatrix4x4 viewMat);
     QOpenGLShaderProgram shader;
-    QOpenGLBuffer vertices;
+    float vbuf[36];
+    QOpenGLBuffer vertices, hud_vertices;
 };
 
 #endif // AXIS_H

--- a/src/axis.h
+++ b/src/axis.h
@@ -9,7 +9,7 @@ class Axis : protected QOpenGLFunctions
 {
 public:
     Axis();
-    void setScale(float* min, float* max);
+    void setScale(QVector3D min, QVector3D max);
     void draw(QMatrix4x4 transMat, QMatrix4x4 viewMat,
         QMatrix4x4 orientMat, QMatrix4x4 aspectMat, float aspectRatio);
 private:

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -10,7 +10,8 @@
 Canvas::Canvas(const QSurfaceFormat& format, QWidget *parent)
     : QOpenGLWidget(parent), mesh(nullptr),
       scale(1), zoom(1), tilt(90), yaw(0),
-      perspective(0.25), anim(this, "perspective"), status(" ")
+      perspective(0.25), anim(this, "perspective"), status(" "),
+      drawMode(shaded), drawAxes(false)
 {
 	setFormat(format);
     QFile styleFile(":/qt/style.qss");
@@ -52,6 +53,12 @@ void Canvas::draw_shaded()
 void Canvas::draw_wireframe()
 {
     set_drawMode(wireframe);
+}
+
+void Canvas::draw_axes(bool d)
+{
+    drawAxes = d;
+    update();
 }
 
 void Canvas::load_mesh(Mesh* m, bool is_reload)

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -65,12 +65,10 @@ void Canvas::draw_axes(bool d)
 void Canvas::load_mesh(Mesh* m, bool is_reload)
 {
     mesh = new GLMesh(m);
-    float min[] = {m->xmin(), m->ymin(), m->zmin()};
-    float max[] = {m->xmax(), m->ymax(), m->zmax()};
+    QVector3D lower(m->xmin(), m->ymin(), m->zmin());
+    QVector3D upper(m->xmax(), m->ymax(), m->zmax());
     if (!is_reload)
     {
-        QVector3D lower(min[0], min[1], min[2]);
-        QVector3D upper(max[0], max[1], max[2]);
         center = (lower + upper) / 2;
         scale = 2 / (upper - lower).length();
 
@@ -80,8 +78,8 @@ void Canvas::load_mesh(Mesh* m, bool is_reload)
         tilt = 90;
     }
     meshInfo = QStringLiteral("Triangles: %1\nX: [%2, %3]\nY: [%4, %5]\nZ: [%6, %7]").arg(m->triCount());
-    for(int dIdx = 0; dIdx < 3; dIdx++) meshInfo = meshInfo.arg(min[dIdx]).arg(max[dIdx]);
-    axis->setScale(min, max);
+    for(int dIdx = 0; dIdx < 3; dIdx++) meshInfo = meshInfo.arg(lower[dIdx]).arg(upper[dIdx]);
+    axis->setScale(lower, upper);
     update();
 
     delete m;

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -46,12 +46,12 @@ void Canvas::view_perspective()
 
 void Canvas::draw_shaded()
 {
-    set_drawMode(0);
+    set_drawMode(shaded);
 }
 
 void Canvas::draw_wireframe()
 {
-    set_drawMode(1);
+    set_drawMode(wireframe);
 }
 
 void Canvas::load_mesh(Mesh* m, bool is_reload)
@@ -88,7 +88,7 @@ void Canvas::set_perspective(float p)
     update();
 }
 
-void Canvas::set_drawMode(int mode)
+void Canvas::set_drawMode(enum DrawMode mode)
 {
     drawMode = mode;
     update();
@@ -134,8 +134,7 @@ void Canvas::paintGL()
 void Canvas::draw_mesh()
 {
     QOpenGLShaderProgram* selected_mesh_shader = NULL;
-    // Set gl draw mode
-    if(drawMode == 1)
+    if(drawMode == wireframe)
     {
         selected_mesh_shader = &mesh_wireframe_shader;
         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -4,6 +4,7 @@
 
 #include "canvas.h"
 #include "backdrop.h"
+#include "axis.h"
 #include "glmesh.h"
 #include "mesh.h"
 
@@ -13,7 +14,7 @@ Canvas::Canvas(const QSurfaceFormat& format, QWidget *parent)
       perspective(0.25), anim(this, "perspective"), status(" "),
       drawMode(shaded), drawAxes(false)
 {
-	setFormat(format);
+    setFormat(format);
     QFile styleFile(":/qt/style.qss");
     styleFile.open( QFile::ReadOnly );
     setStyleSheet(styleFile.readAll());
@@ -119,6 +120,7 @@ void Canvas::initializeGL()
     mesh_wireframe_shader.link();
 
     backdrop = new Backdrop();
+    axis = new Axis();
 }
 
 
@@ -129,6 +131,7 @@ void Canvas::paintGL()
 	glEnable(GL_DEPTH_TEST);
 
 	backdrop->draw();
+	if (drawAxes) axis->draw(transform_matrix(), view_matrix());
 	if (mesh)  draw_mesh();
 
 	if (status.isNull())  return;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -16,7 +16,7 @@ class Canvas : public QOpenGLWidget, protected QOpenGLFunctions
     Q_OBJECT
 
 public:
-	explicit Canvas(const QSurfaceFormat& format, QWidget* parent=0);
+    explicit Canvas(const QSurfaceFormat& format, QWidget* parent=0);
     ~Canvas();
 
     void view_orthographic();
@@ -30,16 +30,16 @@ public slots:
     void load_mesh(Mesh* m, bool is_reload);
 
 protected:
-	void paintGL() override;
-	void initializeGL() override;
-	void resizeGL(int width, int height) override;
+    void paintGL() override;
+    void initializeGL() override;
+    void resizeGL(int width, int height) override;
 
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
     
-	void set_perspective(float p);
+    void set_perspective(float p);
     void set_drawMode(enum DrawMode mode);
     void view_anim(float v);
 
@@ -51,7 +51,7 @@ private:
 
     QOpenGLShaderProgram mesh_shader;
     QOpenGLShaderProgram mesh_wireframe_shader;
-	QOpenGLShaderProgram quad_shader;
+    QOpenGLShaderProgram quad_shader;
 
     GLMesh* mesh;
     Backdrop* backdrop;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -8,6 +8,7 @@
 class GLMesh;
 class Mesh;
 class Backdrop;
+class Axis;
 
 enum DrawMode {shaded, wireframe};
 
@@ -52,10 +53,10 @@ private:
 
     QOpenGLShaderProgram mesh_shader;
     QOpenGLShaderProgram mesh_wireframe_shader;
-    QOpenGLShaderProgram quad_shader;
 
     GLMesh* mesh;
     Backdrop* backdrop;
+    Axis* axis;
 
     QVector3D center;
     float scale;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -23,6 +23,7 @@ public:
     void view_perspective();
     void draw_shaded();
     void draw_wireframe();
+    void draw_axes(bool d);
 
 public slots:
     void set_status(const QString& s);
@@ -64,6 +65,7 @@ private:
 
     float perspective;
     enum DrawMode drawMode;
+    bool drawAxes;
     Q_PROPERTY(float perspective MEMBER perspective WRITE set_perspective);
     QPropertyAnimation anim;
 

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -9,6 +9,8 @@ class GLMesh;
 class Mesh;
 class Backdrop;
 
+enum DrawMode {shaded, wireframe};
+
 class Canvas : public QOpenGLWidget, protected QOpenGLFunctions
 {
     Q_OBJECT
@@ -38,7 +40,7 @@ protected:
     void wheelEvent(QWheelEvent* event) override;
     
 	void set_perspective(float p);
-    void set_drawMode(int mode);
+    void set_drawMode(enum DrawMode mode);
     void view_anim(float v);
 
 private:
@@ -61,7 +63,7 @@ private:
     float yaw;
 
     float perspective;
-    int drawMode;
+    enum DrawMode drawMode;
     Q_PROPERTY(float perspective MEMBER perspective WRITE set_perspective);
     QPropertyAnimation anim;
 

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -74,6 +74,7 @@ private:
 
     QPoint mouse_pos;
     QString status;
+    QString meshInfo;
 };
 
 #endif // CANVAS_H

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -48,7 +48,9 @@ protected:
 private:
     void draw_mesh();
 
+    QMatrix4x4 orient_matrix() const;
     QMatrix4x4 transform_matrix() const;
+    QMatrix4x4 aspect_matrix() const;
     QMatrix4x4 view_matrix() const;
 
     QOpenGLShaderProgram mesh_shader;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,9 @@
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setOrganizationName("mkeeter");
+    QCoreApplication::setOrganizationDomain("https://github.com/mkeeter/fstl");
+    QCoreApplication::setApplicationName("fstl");
     App a(argc, argv);
     return a.exec();
 }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -42,6 +42,10 @@ float Mesh::max(size_t start) const
     return v;
 }
 
+int Mesh::triCount() const
+{
+    return indices.size()/3;
+}
 bool Mesh::empty() const
 {
     return vertices.size() == 0;

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -21,6 +21,7 @@ public:
     float ymax() const { return max(1); }
     float zmax() const { return max(2); }
 
+    int triCount() const;
     bool empty() const;
 
 private:

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -15,6 +15,7 @@ Window::Window(QWidget *parent) :
     orthogonal_action(new QAction("Orthographic", this)),
     shaded_action(new QAction("Shaded", this)),
     wireframe_action(new QAction("Wireframe", this)),
+    axes_action(new QAction("Draw Axes", this)),
     reload_action(new QAction("Reload", this)),
     autoreload_action(new QAction("Autoreload", this)),
     save_screenshot_action(new QAction("Save Screenshot", this)),
@@ -111,6 +112,10 @@ Window::Window(QWidget *parent) :
     drawModes->setExclusive(true);
     QObject::connect(drawModes, &QActionGroup::triggered,
                      this, &Window::on_drawMode);
+    view_menu->addAction(axes_action);
+    axes_action->setCheckable(true);
+    QObject::connect(axes_action, &QAction::triggered,
+            this, &Window::on_drawAxes);
 
     auto help_menu = menuBar()->addMenu("Help");
     help_menu->addAction(about_action);
@@ -224,6 +229,11 @@ void Window::on_drawMode(QAction* mode)
     {
         canvas->draw_wireframe();
     }
+}
+
+void Window::on_drawAxes(bool d)
+{
+    canvas->draw_axes(d);
 }
 
 void Window::on_watched_change(const QString& filename)

--- a/src/window.h
+++ b/src/window.h
@@ -38,6 +38,7 @@ public slots:
 private slots:
     void on_projection(QAction* proj);
     void on_drawMode(QAction* mode);
+    void on_drawAxes(bool d);
     void on_watched_change(const QString& filename);
     void on_reload();
     void on_autoreload_triggered(bool r);
@@ -59,6 +60,7 @@ private:
     QAction* const orthogonal_action;
     QAction* const shaded_action;
     QAction* const wireframe_action;
+    QAction* const axes_action;
     QAction* const reload_action;
     QAction* const autoreload_action;
     QAction* const save_screenshot_action;

--- a/src/window.h
+++ b/src/window.h
@@ -45,7 +45,7 @@ private slots:
     void on_load_recent(QAction* a);
     void on_loaded(const QString& filename);
     void on_save_screenshot();
-	
+
 private:
     void rebuild_recent_files();
     void sorted_insert(QStringList& list, const QCollator& collator, const QString& value);


### PR DESCRIPTION
Added an option to show model-space axes, an axis flower, and model info.
![image](https://user-images.githubusercontent.com/7738815/87204776-4e896c00-c2cb-11ea-81fe-3a53f7f344f5.png)
![image](https://user-images.githubusercontent.com/7738815/87205314-c5733480-c2cc-11ea-90b7-405f05534406.png)

Also:
 - Standardized various formatting (tabs ->spaces)
 - Removed unused Canvas.quad_shader
 - Converted drawmode to an enum for more readability
 - quad.frag and colored_lines.frag are identical. I left them separate for clarity, but I can merge them into a color_frag.frag if you'd prefer.

No part of this change should be platform dependent, but I have only tested on 64bit linux, qt 5.15.0.
I look forward to your thoughts. Thanks,
Martin