### PR TITLE
Add --version flag with -V alias via QCommandLineParser

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,11 +33,14 @@ jobs:
                 echo "CC=$CC" >> $GITHUB_ENV
                 echo "CXX=$CXX" >> $GITHUB_ENV
 
-            - name: Build 
+            - name: Build
               run: |
                 cmake -S . -B build -DFSTL_CHECK_FORMAT=ON
                 cmake --build build --target fstl --config Release -- -j$(nproc)
-            
+
+            - name: Run tests
+              run: ctest --test-dir build --output-on-failure
+
             - name: Check format
               run: |
                 # Print the version for troubleshooting purposes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,21 +122,13 @@ target_compile_definitions(fstl PRIVATE -DFSTL_VERSION="${PROJECT_VERSION}")
 # Escape dots in PROJECT_VERSION so version is matched literally in the regex. Use character class to avoid backslash escaping issues.
 string(REPLACE "." "[.]" PROJECT_VERSION_ESCAPED "${PROJECT_VERSION}")
 
-if(NOT WIN32)
-    enable_testing()
-    add_test(NAME version_check COMMAND $<TARGET_FILE:fstl> --version)
-    set_tests_properties(version_check PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION_ESCAPED}")
+enable_testing()
+add_test(NAME version_check COMMAND $<TARGET_FILE:fstl> --version)
+set_tests_properties(version_check PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION_ESCAPED}")
 
-    # Also validate the short alias `-V` produces the same output.
-    add_test(NAME version_check_short COMMAND $<TARGET_FILE:fstl> -V)
-    set_tests_properties(version_check_short PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION_ESCAPED}")
-
-    # Validate lowercase `-v` also produces the same output.
-    add_test(NAME version_check_v COMMAND $<TARGET_FILE:fstl> -v)
-    set_tests_properties(version_check_v PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION_ESCAPED}")
-else()
-    message(STATUS "Skipping version_check tests on WIN32 (GUI targets may not provide stdout)")
-endif()
+# Also validate the POSIX-compliant short alias `-V` produces the same output.
+add_test(NAME version_check_V COMMAND $<TARGET_FILE:fstl> -V)
+set_tests_properties(version_check_V PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION_ESCAPED}")
 
 #installer information that is platform independent
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Fast .stl file viewer.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,13 +119,24 @@ target_link_libraries(fstl Qt5::Widgets Qt5::Core Qt5::Gui Qt5::OpenGL ${OPENGL_
 target_compile_definitions(fstl PRIVATE -DFSTL_VERSION="${PROJECT_VERSION}")
 
 # Enable a simple test that validates the CLI `--version` output is exact.
-enable_testing()
-add_test(NAME version_check COMMAND $<TARGET_FILE:fstl> --version)
-set_tests_properties(version_check PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION}")
+# Escape dots in PROJECT_VERSION so version is matched literally in the regex. Use character class to avoid backslash escaping issues.
+string(REPLACE "." "[.]" PROJECT_VERSION_ESCAPED "${PROJECT_VERSION}")
 
-# Also validate the short alias `-V` produces the same output.
-add_test(NAME version_check_short COMMAND $<TARGET_FILE:fstl> -V)
-set_tests_properties(version_check_short PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION}")
+if(NOT WIN32)
+    enable_testing()
+    add_test(NAME version_check COMMAND $<TARGET_FILE:fstl> --version)
+    set_tests_properties(version_check PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION_ESCAPED}")
+
+    # Also validate the short alias `-V` produces the same output.
+    add_test(NAME version_check_short COMMAND $<TARGET_FILE:fstl> -V)
+    set_tests_properties(version_check_short PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION_ESCAPED}")
+
+    # Validate lowercase `-v` also produces the same output.
+    add_test(NAME version_check_v COMMAND $<TARGET_FILE:fstl> -v)
+    set_tests_properties(version_check_v PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION_ESCAPED}")
+else()
+    message(STATUS "Skipping version_check tests on WIN32 (GUI targets may not provide stdout)")
+endif()
 
 #installer information that is platform independent
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Fast .stl file viewer.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,15 @@ target_link_libraries(fstl Qt5::Widgets Qt5::Core Qt5::Gui Qt5::OpenGL ${OPENGL_
 # Add version definitions to use within the code. 
 target_compile_definitions(fstl PRIVATE -DFSTL_VERSION="${PROJECT_VERSION}")
 
+# Enable a simple test that validates the CLI `--version` output is exact.
+enable_testing()
+add_test(NAME version_check COMMAND $<TARGET_FILE:fstl> --version)
+set_tests_properties(version_check PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION}")
+
+# Also validate the short alias `-V` produces the same output.
+add_test(NAME version_check_short COMMAND $<TARGET_FILE:fstl> -V)
+set_tests_properties(version_check_short PROPERTIES PASS_REGULAR_EXPRESSION "fstl ${PROJECT_VERSION}")
+
 #installer information that is platform independent
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Fast .stl file viewer.")
 set(CPACK_PACKAGE_VERSION_MAJOR ${FSTL_VERSION_MAJOR})

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,7 @@
 #include <QApplication>
+#include <QCommandLineParser>
 
 #include "app.h"
-
-#include <iostream>
-#include <cstring>
 
 int main(int argc, char* argv[])
 {
@@ -15,17 +13,27 @@ int main(int argc, char* argv[])
     QCoreApplication::setApplicationName("fstl");
     QCoreApplication::setApplicationVersion(FSTL_VERSION);
 
-    // If user asked for the version, print and exit immediately.
-    // Use raw argv comparison to avoid any QString conversion edge-cases.
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--version") == 0 || std::strcmp(argv[i], "-V") == 0 || std::strcmp(argv[i], "-v") == 0) {
-            std::cout << QCoreApplication::applicationName().toStdString() << " "
-                      << QCoreApplication::applicationVersion().toStdString() << std::endl;
-            return 0;
-        }
-    }
-
     App a(argc, argv);
+
+    // Set up QCommandLineParser to handle --help, --version, and file argument
+    QCommandLineParser parser;
+    parser.setApplicationDescription("Fast .stl file viewer");
+    parser.addHelpOption();
+    
+    // Add custom version option with both -V (uppercase, POSIX) and --version
+    QCommandLineOption versionOption(QStringList() << "V" << "version", "Displays version information.");
+    parser.addOption(versionOption);
+    
+    parser.addPositionalArgument("file", "STL file to open (optional)", "[file]");
+    parser.process(a);
+    
+    // Handle version option manually since we use custom -V
+    if (parser.isSet(versionOption)) {
+        printf("%s %s\n", 
+               QCoreApplication::applicationName().toStdString().c_str(),
+               QCoreApplication::applicationVersion().toStdString().c_str());
+        return 0;
+    }
 
     return a.exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,9 @@
 
 #include "app.h"
 
+#include <iostream>
+#include <cstring>
+
 int main(int argc, char* argv[])
 {
     // Force C locale to force decimal point
@@ -11,6 +14,17 @@ int main(int argc, char* argv[])
     QCoreApplication::setOrganizationDomain("https://github.com/fstl-app/fstl");
     QCoreApplication::setApplicationName("fstl");
     QCoreApplication::setApplicationVersion(FSTL_VERSION);
+
+    // If user asked for the version, print and exit immediately.
+    // Use raw argv comparison to avoid any QString conversion edge-cases.
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--version") == 0 || std::strcmp(argv[i], "-V") == 0) {
+            std::cout << QCoreApplication::applicationName().toStdString() << " "
+                      << QCoreApplication::applicationVersion().toStdString() << std::endl;
+            return 0;
+        }
+    }
+
     App a(argc, argv);
 
     return a.exec();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* argv[])
     // If user asked for the version, print and exit immediately.
     // Use raw argv comparison to avoid any QString conversion edge-cases.
     for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--version") == 0 || std::strcmp(argv[i], "-V") == 0) {
+        if (std::strcmp(argv[i], "--version") == 0 || std::strcmp(argv[i], "-V") == 0 || std::strcmp(argv[i], "-v") == 0) {
             std::cout << QCoreApplication::applicationName().toStdString() << " "
                       << QCoreApplication::applicationVersion().toStdString() << std::endl;
             return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <QApplication>
 #include <QCommandLineParser>
 
@@ -29,9 +30,8 @@ int main(int argc, char* argv[])
     
     // Handle version option manually since we use custom -V
     if (parser.isSet(versionOption)) {
-        printf("%s %s\n", 
-               QCoreApplication::applicationName().toStdString().c_str(),
-               QCoreApplication::applicationVersion().toStdString().c_str());
+        std::cout << QCoreApplication::applicationName().toStdString() << " "
+                  << QCoreApplication::applicationVersion().toStdString() << "\n";
         return 0;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char* argv[])
     parser.addHelpOption();
     
     // Add custom version option with both -V (uppercase, POSIX) and --version
-    QCommandLineOption versionOption(QStringList() << "V" << "version", "Displays version information.");
+    QCommandLineOption versionOption(QStringList{"V", "version"}, "Displays version information.");
     parser.addOption(versionOption);
     
     parser.addPositionalArgument("file", "STL file to open (optional)", "[file]");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,11 @@
-#include <iostream>
 #include <QApplication>
 #include <QCommandLineParser>
+#include <cstdio>
+#include <iostream>
+
+#ifdef Q_OS_WIN
+#    include <windows.h>
+#endif
 
 #include "app.h"
 
@@ -9,32 +14,58 @@ int main(int argc, char* argv[])
     // Force C locale to force decimal point
     QLocale::setDefault(QLocale::c());
 
+#ifdef Q_OS_WIN
+    // WIN32 GUI subsystem has no console by default; skip streams already redirected.
+    if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+        if (GetFileType(GetStdHandle(STD_OUTPUT_HANDLE)) == FILE_TYPE_UNKNOWN) {
+            freopen("CONOUT$", "w", stdout);
+        }
+        if (GetFileType(GetStdHandle(STD_ERROR_HANDLE)) == FILE_TYPE_UNKNOWN) {
+            freopen("CONOUT$", "w", stderr);
+        }
+    }
+#endif
+
     QCoreApplication::setOrganizationName("fstl-app");
     QCoreApplication::setOrganizationDomain("https://github.com/fstl-app/fstl");
     QCoreApplication::setApplicationName("fstl");
     QCoreApplication::setApplicationVersion(FSTL_VERSION);
+
+    // Parse --version/-V/--help before constructing App/QApplication, so no
+    // window is created and argv[1] isn't treated as a filename for these
+    // flags. parse() (not process()) so App's QApplication can still handle
+    // its own options (-style, -platform, etc.) unrejected.
+    {
+        QCoreApplication pre(argc, argv);
+
+        QCommandLineParser parser;
+        parser.setApplicationDescription("Fast .stl file viewer");
+        QCommandLineOption helpOption = parser.addHelpOption();
+
+        // Add custom version option with both -V (uppercase, POSIX) and --version
+        QCommandLineOption versionOption(QStringList{"V", "version"}, "Displays version information.");
+        parser.addOption(versionOption);
+
+        // For --help text only; App (app.cpp) reads argv directly for the file.
+        parser.addPositionalArgument("file", "STL file to open (optional)", "[file]");
+
+        parser.parse(pre.arguments());
+
+        if (parser.isSet(helpOption)) {
+            parser.showHelp(0);
+        }
+
+        // Handle version option manually since we use custom -V
+        if (parser.isSet(versionOption)) {
+            std::cout << QCoreApplication::applicationName().toStdString() << " "
+                      << QCoreApplication::applicationVersion().toStdString() << "\n";
+            return 0;
+        }
+    }
+
     QGuiApplication::setDesktopFileName("fstlapp-fstl.desktop");
 
     App a(argc, argv);
-
-    // Set up QCommandLineParser to handle --help, --version, and file argument
-    QCommandLineParser parser;
-    parser.setApplicationDescription("Fast .stl file viewer");
-    parser.addHelpOption();
-    
-    // Add custom version option with both -V (uppercase, POSIX) and --version
-    QCommandLineOption versionOption(QStringList{"V", "version"}, "Displays version information.");
-    parser.addOption(versionOption);
-    
-    parser.addPositionalArgument("file", "STL file to open (optional)", "[file]");
-    parser.process(a);
-    
-    // Handle version option manually since we use custom -V
-    if (parser.isSet(versionOption)) {
-        std::cout << QCoreApplication::applicationName().toStdString() << " "
-                  << QCoreApplication::applicationVersion().toStdString() << "\n";
-        return 0;
-    }
 
     return a.exec();
 }


### PR DESCRIPTION
Implement version flag handling using Qt's QCommandLineParser with cross-platform tests.

Changes
- Replace manual argv parsing with QCommandLineParser
- Support --version and -V (POSIX-compliant) for version output
- Enable version tests on all platforms (remove WIN32 restriction)
- Rename tests: version_check (--version) and version_check_V (-V)

Benefits
- Qt best practices
- Cross-platform support
- Automatic --help generation
- POSIX conventions